### PR TITLE
Update to Feathers Buzzard (v3)

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -1,18 +1,16 @@
-const errors = require('feathers-errors');
+const errors = require('@feathersjs/errors');
 
 module.exports = function errorHandler (error) {
-  let feathersError = error;
-
   // NOTE (EK): The list of error code is way too massive to map
   // them to a specific error object so we'll use a generic one.
   // See https://github.com/mongodb/mongo/blob/master/docs/errors.md
 
   if (error.name === 'MongoError') {
-    feathersError = new errors.GeneralError(error, {
+    throw new errors.GeneralError(error, {
       ok: error.ok,
       code: error.code
     });
   }
 
-  throw feathersError;
+  throw error;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,16 +1,10 @@
 const omit = require('lodash.omit');
 
-const {
-  ObjectID
-} = require('mongodb');
-
+const { ObjectID } = require('mongodb');
 const Proto = require('uberproto');
-const filter = require('feathers-query-filters');
-const errors = require('feathers-errors');
 
-const {
-  select
-} = require('feathers-commons');
+const errors = require('@feathersjs/errors');
+const { select, filterQuery } = require('@feathersjs/commons');
 
 const errorHandler = require('./error-handler');
 
@@ -40,7 +34,7 @@ class Service {
   }
 
   _multiOptions (id, params) {
-    let query = filter(params.query || {}).query;
+    let query = filterQuery(params.query || {}).query;
     let options = Object.assign({ multi: true }, params.mongodb || params.options);
 
     if (id !== null) {
@@ -63,7 +57,7 @@ class Service {
     return select;
   }
 
-  _find (params, count, getFilter = filter) {
+  _find (params, count, getFilter = filterQuery) {
     // Start with finding all, and limit when necessary.
     let { filters, query } = getFilter(params.query || {});
 
@@ -126,7 +120,7 @@ class Service {
   find (params) {
     const paginate = (params && typeof params.paginate !== 'undefined') ? params.paginate : this.paginate;
     const result = this._find(params, !!paginate.default,
-      query => filter(query, paginate)
+      query => filterQuery(query, paginate)
     );
 
     if (!paginate.default) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,19 +4,65 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/node": {
-      "version": "8.0.53",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.53.tgz",
-      "integrity": "sha512-54Dm6NwYeiSQmRB1BLXKr5GELi0wFapR1npi8bnZhEcu84d/yQKqnwwXQ56hZ0RUbTG6L5nqDZaN3dgByQXQRQ==",
-      "dev": true
+    "@feathersjs/commons": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-1.3.0.tgz",
+      "integrity": "sha512-/2Fevm/g0hIe79A81eMOScPNtoWIuHk1LwXCLJGeuGKoTUnzd/xJLSFesSq7dlePDtwMtuR8apnB1CM49iCy+g=="
     },
-    "@types/socket.io": {
-      "version": "1.4.31",
-      "resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-1.4.31.tgz",
-      "integrity": "sha512-HnO78rKiAx+tCEKYFurJvKLNAluN9B0V+yLnkJEY9BVwmCXHA7oKeLCymqP/uAgx0t+un/JM+GJOTwNQJ+ODvQ==",
+    "@feathersjs/errors": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-3.2.0.tgz",
+      "integrity": "sha512-4xsE7OyzxGvs2hyG19nf2qb4rV2nWoWbQ6/FnDIYrNHi7M9kOy+deLwNhKnXa4r/hg3xf+AVpC8kBjUQjWYWHA==",
+      "requires": {
+        "debug": "3.1.0"
+      }
+    },
+    "@feathersjs/express": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@feathersjs/express/-/express-1.1.2.tgz",
+      "integrity": "sha512-oxXZs3QAZB80fBajb7nh3Pbongm8ESXVnJw1EuX7fui4JOXh2qGw9hf8e3xKAZ/fmkHmgofdA1A3iqIzBg3Isw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.53"
+        "@feathersjs/commons": "1.3.0",
+        "@feathersjs/errors": "3.2.0",
+        "debug": "3.1.0",
+        "express": "4.16.2",
+        "uberproto": "1.2.0"
+      }
+    },
+    "@feathersjs/feathers": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@feathersjs/feathers/-/feathers-3.0.1.tgz",
+      "integrity": "sha512-uRvzpnpwdW31+hQ67sGPQAQm09hmZrw1nc5om9yoSTouszjREcM2qusJkyWXN67/8Uythge6OjlYIP0NFJHVaw==",
+      "dev": true,
+      "requires": {
+        "@feathersjs/commons": "1.3.0",
+        "debug": "3.1.0",
+        "events": "1.1.1",
+        "uberproto": "1.2.0"
+      }
+    },
+    "@feathersjs/socket-commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@feathersjs/socket-commons/-/socket-commons-3.0.1.tgz",
+      "integrity": "sha512-/WgXC7tODg16uCGK5SKQYg3NvCdchJQyvBD1F0ljKWCee8N+Ep5TprN+i0/Ip4hAwWsQMQ7HIKBKdDvJ32aYyA==",
+      "dev": true,
+      "requires": {
+        "@feathersjs/errors": "3.2.0",
+        "debug": "3.1.0",
+        "lodash": "4.17.4",
+        "url-pattern": "1.0.3"
+      }
+    },
+    "@feathersjs/socketio": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@feathersjs/socketio/-/socketio-3.0.1.tgz",
+      "integrity": "sha512-YZFpj52tu1QrO/n74CyeceCZ20dr3CIN6cGYHTbvl+As+aNY7yzQTvUVKBOrOfLUu/tuI4u1W+BzH+30+9ySSA==",
+      "dev": true,
+      "requires": {
+        "@feathersjs/socket-commons": "3.0.1",
+        "debug": "3.1.0",
+        "socket.io": "2.0.4"
       }
     },
     "abbrev": {
@@ -262,30 +308,14 @@
         "babel-runtime": "6.26.0"
       }
     },
-    "babel-polyfill": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.10.5"
-      }
-    },
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
       "requires": {
         "core-js": "2.5.1",
         "regenerator-runtime": "0.11.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
-        }
       }
     },
     "babel-template": {
@@ -621,6 +651,12 @@
         "delayed-stream": "1.0.0"
       }
     },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
+    },
     "component-bind": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
@@ -652,7 +688,7 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.2.7",
         "typedarray": "0.0.6"
       }
     },
@@ -689,7 +725,8 @@
     "core-js": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1152,15 +1189,6 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
-        },
-        "user-home": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-          "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-          "dev": true,
-          "requires": {
-            "os-homedir": "1.0.2"
-          }
         }
       }
     },
@@ -1261,6 +1289,12 @@
             "esutils": "2.0.2",
             "isarray": "1.0.0"
           }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
         }
       }
     },
@@ -1313,6 +1347,12 @@
             "esutils": "2.0.2",
             "isarray": "1.0.0"
           }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
         }
       }
     },
@@ -1443,18 +1483,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "setprototypeof": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-          "dev": true
-        },
-        "statuses": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-          "dev": true
         }
       }
     },
@@ -1487,64 +1515,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
-    },
-    "feathers": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/feathers/-/feathers-2.2.3.tgz",
-      "integrity": "sha512-p2dgIbhD5IBZRN2At2hahg0KHnyRLIL0sQE+5Ci+GlAHPEQtAVUSgfWqTAOMiNFelHUqlFZSREnXH0VsuV3NOw==",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "debug": "3.1.0",
-        "events": "1.1.1",
-        "express": "4.16.2",
-        "feathers-commons": "0.8.7",
-        "rubberduck": "1.1.1",
-        "uberproto": "1.2.0"
-      }
-    },
-    "feathers-commons": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/feathers-commons/-/feathers-commons-0.8.7.tgz",
-      "integrity": "sha1-EcbyW1N3RamD6NYVUtfbiTLVN4I="
-    },
-    "feathers-errors": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/feathers-errors/-/feathers-errors-2.9.2.tgz",
-      "integrity": "sha512-qwIX97bNW7+1tWVG073+omUA0rCYKJtTtwuzTrrvfrtdr8J8Dk1Fy4iaV9Fa6/YBD5AZu0lsplPE0iu4u/d4GQ==",
-      "requires": {
-        "debug": "3.1.0"
-      }
-    },
-    "feathers-hooks": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/feathers-hooks/-/feathers-hooks-2.1.2.tgz",
-      "integrity": "sha512-XQKhbo4d4TuXyco+tbHmKn5wo8QhdSNslJ/+zckNYfUzLmrN8L3uB4Utf0/ivcgwWxJtS1kVhEETBN4TDxuWFg==",
-      "dev": true,
-      "requires": {
-        "feathers-commons": "0.8.7",
-        "uberproto": "1.2.0"
-      }
-    },
-    "feathers-query-filters": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/feathers-query-filters/-/feathers-query-filters-2.1.2.tgz",
-      "integrity": "sha1-zbGCJNteGcwBQNUoEI4JCNXrBlQ=",
-      "requires": {
-        "feathers-commons": "0.8.7"
-      }
-    },
-    "feathers-rest": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/feathers-rest/-/feathers-rest-1.8.1.tgz",
-      "integrity": "sha512-FYVcBQLGocSdpjxEf+E/9Cb0QAX0S+biqRgB5KAGpoAF51cou9LV0WW1IwqwHzAT67KRyS4dT7fVCrE4kisM2w==",
-      "dev": true,
-      "requires": {
-        "debug": "3.1.0",
-        "feathers-commons": "0.8.7",
-        "feathers-errors": "2.9.2",
-        "qs": "6.5.1"
-      }
     },
     "feathers-service-tests": {
       "version": "0.10.2",
@@ -1591,41 +1561,6 @@
           "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
           "dev": true
         }
-      }
-    },
-    "feathers-socket-commons": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/feathers-socket-commons/-/feathers-socket-commons-2.4.0.tgz",
-      "integrity": "sha1-Bi79V/mocWZEFFuZOl9ycJlp8eE=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.9",
-        "feathers-commons": "0.8.7",
-        "feathers-errors": "2.9.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "feathers-socketio": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/feathers-socketio/-/feathers-socketio-2.0.1.tgz",
-      "integrity": "sha512-3ByXVr6UGyGN6TPRN+U5IhENYrSgeuADhbKWLG5cq2WvYH9h2N1l3cj7WBVsfRektUgVw/HkGNAoExy8yuknMA==",
-      "dev": true,
-      "requires": {
-        "@types/socket.io": "1.4.31",
-        "debug": "3.1.0",
-        "feathers-socket-commons": "2.4.0",
-        "socket.io": "2.0.4",
-        "uberproto": "1.2.0"
       }
     },
     "figures": {
@@ -1681,12 +1616,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "statuses": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-          "dev": true
         }
       }
     },
@@ -1911,14 +1840,6 @@
       "dev": true,
       "requires": {
         "isarray": "2.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
-          "dev": true
-        }
       }
     },
     "has-cors": {
@@ -1966,7 +1887,15 @@
         "depd": "1.1.1",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
-        "statuses": "1.4.0"
+        "statuses": "1.3.1"
+      },
+      "dependencies": {
+        "setprototypeof": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+          "dev": true
+        }
       }
     },
     "http-signature": {
@@ -2183,9 +2112,9 @@
       "dev": true
     },
     "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+      "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
       "dev": true
     },
     "isexe": {
@@ -2584,12 +2513,6 @@
         "supports-color": "4.4.0"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-          "dev": true
-        },
         "has-flag": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
@@ -2616,23 +2539,6 @@
         "es6-promise": "3.2.1",
         "mongodb-core": "2.1.17",
         "readable-stream": "2.2.7"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.2.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
-          "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
-          "dev": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        }
       }
     },
     "mongodb-core": {
@@ -3009,18 +2915,26 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
+      "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
       "dev": true,
       "requires": {
+        "buffer-shims": "1.0.0",
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
         "isarray": "1.0.0",
         "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
         "string_decoder": "1.0.3",
         "util-deprecate": "1.0.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        }
       }
     },
     "readline2": {
@@ -3044,9 +2958,10 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+      "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
@@ -3186,12 +3101,6 @@
         "glob": "7.1.2"
       }
     },
-    "rubberduck": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/rubberduck/-/rubberduck-1.1.1.tgz",
-      "integrity": "sha1-zSzaS4ZxeBNer8mVpxOE9fdD2wI=",
-      "dev": true
-    },
     "run-async": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
@@ -3272,12 +3181,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "statuses": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-          "dev": true
         }
       }
     },
@@ -3294,9 +3197,9 @@
       }
     },
     "setprototypeof": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
       "dev": true
     },
     "shelljs": {
@@ -3407,12 +3310,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "isarray": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
-          "dev": true
         }
       }
     },
@@ -3465,9 +3362,9 @@
       }
     },
     "statuses": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
       "dev": true
     },
     "stealthy-require": {
@@ -3722,6 +3619,21 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
+    },
+    "url-pattern": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/url-pattern/-/url-pattern-1.0.3.tgz",
+      "integrity": "sha1-BAkpJHGyTyPFDWWkeTF5PStaz8E=",
+      "dev": true
+    },
+    "user-home": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -54,21 +54,17 @@
     "node": ">= 6"
   },
   "dependencies": {
-    "babel-polyfill": "^6.7.4",
-    "feathers-commons": "^0.8.4",
-    "feathers-errors": "^2.0.1",
-    "feathers-query-filters": "^2.0.0",
+    "@feathersjs/commons": "^1.3.0",
+    "@feathersjs/errors": "^3.2.0",
     "lodash.omit": "^4.3.0",
     "uberproto": "^1.2.0"
   },
   "devDependencies": {
-    "body-parser": "^1.14.1",
+    "@feathersjs/express": "^1.1.2",
+    "@feathersjs/feathers": "^3.0.1",
+    "@feathersjs/socketio": "^3.0.1",
     "chai": "^4.0.0",
-    "feathers": "^2.0.0-pre.4",
-    "feathers-hooks": "^2.0.0",
-    "feathers-rest": "^1.2.2",
     "feathers-service-tests": "^0.10.0",
-    "feathers-socketio": "^2.0.0",
     "istanbul": "^1.1.0-alpha.1",
     "mocha": "^4.0.0",
     "mongodb": "^2.2.19",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,8 +3,8 @@ const { base } = require('feathers-service-tests');
 
 const { MongoClient, ObjectID } = require('mongodb');
 
-const feathers = require('feathers');
-const errors = require('feathers-errors');
+const feathers = require('@feathersjs/feathers');
+const errors = require('@feathersjs/errors');
 const service = require('../lib');
 
 describe('Feathers MongoDB Service', () => {


### PR DESCRIPTION
This updates the development dependencies to Feathers Buzzard. New release will stay compatible with previous versions of Feathers.

Previous versions of `feathers-mongodb` are also compatible with Feathers Buzzard.