### PR TITLE
Allow $modifiers to be used in patch

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -196,7 +196,7 @@ class Service {
     // Step through the rooot
     for (var key in data) {
       // Check for keys that aren't modifiers
-      if (key.charAt(0) !== "$"){
+      if (key.charAt(0) !== '$') {
         // Move them to set, and remove their record
         set[key] = data[key];
         delete data[key];
@@ -207,7 +207,10 @@ class Service {
         delete data[key];
       }
     }
-    data['$set'] = set;
+    // If we have a $set, then attach to the data object
+    if (Object.keys(set).length > 0) {
+      data['$set'] = set;
+    }
     return data;
   }
 
@@ -235,9 +238,9 @@ class Service {
             [this.id]: { $in: idList }
           }
         });
-        data = this._remapModifiers(data);
+
         return this.Model
-          .update(query, this._normalizeId(id, data), options)
+          .update(query, this._remapModifiers(this._normalizeId(id, data)), options)
           .then(() => this._findOrGet(id, findParams));
       })
       .then(select(params, this.id))
@@ -250,7 +253,7 @@ class Service {
     }
 
     let { query, options } = this._multiOptions(id, params);
-    
+
     return this.Model
       .update(query, this._normalizeId(id, data), options)
       .then(() => this._findOrGet(id))

--- a/lib/index.js
+++ b/lib/index.js
@@ -250,7 +250,7 @@ class Service {
     }
 
     let { query, options } = this._multiOptions(id, params);
-    data = this._remapModifiers(data);
+    
     return this.Model
       .update(query, this._normalizeId(id, data), options)
       .then(() => this._findOrGet(id))

--- a/lib/index.js
+++ b/lib/index.js
@@ -190,6 +190,27 @@ class Service {
     }
   }
 
+  // Map stray records into $set
+  _remapModifiers (data) {
+    var set = {};
+    // Step through the rooot
+    for (var key in data) {
+      // Check for keys that aren't modifiers
+      if (key.charAt(0) !== "$"){
+        // Move them to set, and remove their record
+        set[key] = data[key];
+        delete data[key];
+      }
+      // If the '$set' modifier is used, add that to the temp variable
+      if (key === '$set') {
+        set = Object.assign(set, data[key]);
+        delete data[key];
+      }
+    }
+    data['$set'] = set;
+    return data;
+  }
+
   patch (id, data, params) {
     let { query, options } = this._multiOptions(id, params);
     const mapIds = page => page.data.map(current => current[this.id]);
@@ -214,9 +235,9 @@ class Service {
             [this.id]: { $in: idList }
           }
         });
-
+        data = this._remapModifiers(data);
         return this.Model
-          .update(query, { $set: this._normalizeId(id, data) }, options)
+          .update(query, this._normalizeId(id, data), options)
           .then(() => this._findOrGet(id, findParams));
       })
       .then(select(params, this.id))
@@ -229,7 +250,7 @@ class Service {
     }
 
     let { query, options } = this._multiOptions(id, params);
-
+    data = this._remapModifiers(data);
     return this.Model
       .update(query, this._normalizeId(id, data), options)
       .then(() => this._findOrGet(id))

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -229,7 +229,7 @@ describe('Feathers MongoDB Service', () => {
     
     it('pushes to an array using patch', () => {
       return peopleService
-        .patch(null, { $push: {friends: 'Adam'} }, { query: { name: { $gt: 'AAA' } })
+        .patch(null, { $push: {friends: 'Adam'} }, { query: { name: { $gt: 'AAA' } }})
         .then(r => {
           expect(r[0].friends).to.have.lengthOf(1);
         });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -226,7 +226,7 @@ describe('Feathers MongoDB Service', () => {
           expect(r[0].name).to.equal('ccc');
         });
     });
-    
+
     it('pushes to an array using patch', () => {
       return peopleService
         .patch(null, { $push: { friends: 'Adam' } }, { query: { name: { $gt: 'AAA' } } })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -229,7 +229,7 @@ describe('Feathers MongoDB Service', () => {
     
     it('pushes to an array using patch', () => {
       return peopleService
-        .patch(null, { $push: {friends: 'Adam'} }, { query: { name: { $gt: 'AAA' } }})
+        .patch(null, { $push: { friends: 'Adam' } }, { query: { name: { $gt: 'AAA' } } })
         .then(r => {
           expect(r[0].friends).to.have.lengthOf(1);
         });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -232,6 +232,11 @@ describe('Feathers MongoDB Service', () => {
         .patch(null, { $push: { friends: 'Adam' } }, { query: { name: { $gt: 'AAA' } } })
         .then(r => {
           expect(r[0].friends).to.have.lengthOf(1);
+          return peopleService
+            .patch(null, { $push: { friends: 'Bell' } }, { query: { name: { $gt: 'AAA' } } })
+            .then(r => {
+              expect(r[0].friends).to.have.lengthOf(2);
+            });
         });
     });
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -226,6 +226,13 @@ describe('Feathers MongoDB Service', () => {
           expect(r[0].name).to.equal('ccc');
         });
     });
-
+    
+    it('pushes to an array using patch', () => {
+      return peopleService
+        .patch(null, { $push: {friends: 'Adam'} }, { query: { name: { $gt: 'AAA' } })
+        .then(r => {
+          expect(r[0].friends).to.have.lengthOf(1);
+        });
+    });
   });
 });


### PR DESCRIPTION
This is a resolution to #101

Removes the hard coded { $set: data } out of patch, and added a function that checks for records that are not under an existing modifier, and remaps them to $set. 