### PR TITLE
using countDocuments() instead of count()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -111,7 +111,7 @@ class Service {
     }
 
     if (count) {
-      return this.Model.count(query).then(runQuery);
+      return this.Model.countDocuments(query).then(runQuery);
     }
 
     return runQuery();


### PR DESCRIPTION
Handle the following DeprecationWarning message for feathers-mongodb driver users:

`DeprecationWarning: collection.count is deprecated, and will be removed in a future version. Use collection.countDocuments or collection.estimatedDocumentCount instead`