### PR TITLE
Add hint support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -79,6 +79,10 @@ class Service {
     if (params.collation) {
       q.collation(params.collation);
     }
+    
+    if (params.hint) {
+      q.hint(params.hint);
+    }
 
     if (filters.$limit) {
       q.limit(filters.$limit);

--- a/lib/index.js
+++ b/lib/index.js
@@ -79,7 +79,7 @@ class Service {
     if (params.collation) {
       q.collation(params.collation);
     }
-    
+
     if (params.hint) {
       q.hint(params.hint);
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -31,6 +31,11 @@ describe('Feathers MongoDB Service', () => {
         db.collection('people-customid').removeMany();
         db.collection('people').removeMany();
         db.collection('todos').removeMany();
+
+        db.collection('people').createIndex(
+          { name: 1 },
+          { partialFilterExpression: { team: 'blue' } }
+        );
       })
   );
 
@@ -236,6 +241,18 @@ describe('Feathers MongoDB Service', () => {
             .patch(null, { $push: { friends: 'Bell' } }, { query: { name: { $gt: 'AAA' } } })
             .then(r => {
               expect(r[0].friends).to.have.lengthOf(2);
+            });
+        });
+    });
+
+    it('overrides default index selection using hint param if present', () => {
+      return peopleService
+        .create({ name: 'Indexed', team: 'blue' })
+        .then(r => {
+          return peopleService
+            .find({ query: { }, hint: { name: 1 } })
+            .then(r => {
+              expect(r).to.have.lengthOf(1);
             });
         });
     });


### PR DESCRIPTION
### Summary

Adds support for the `hint` param in `find` queries: https://docs.mongodb.com/manual/reference/method/cursor.hint/

### Other Information

Usage examples:

```
const query = { userId: 12345 };
const hint = { userId: 1 };
users.find({ query, hint }).then( ... );
```

```
const query = { userId: 12345 };
const hint = "index_name";
users.find({ query, hint }).then( ... );
```