### PR TITLE
Fix support for string ID's

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -171,8 +171,8 @@ class Service extends AdapterService {
     const { query } = this.filterQuery(params);
 
     query.$or = (query.$or || [])
-      .concat({ [this.id]: this._objectifyId(id) })
       .concat({ [this.id]: id })
+      .concat({ [this.id]: this._objectifyId(id) })
 
     return this.Model.findOne(query).then(data => {
       if (!data) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -170,7 +170,9 @@ class Service extends AdapterService {
   _get (id, params = {}) {
     const { query } = this.filterQuery(params);
 
-    query.$and = (query.$and || []).concat({ [this.id]: this._objectifyId(id) });
+    query.$or = (query.$or || [])
+      .concat({ [this.id]: this._objectifyId(id) })
+      .concat({ [this.id]: id })
 
     return this.Model.findOne(query).then(data => {
       if (!data) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -234,6 +234,15 @@ describe('Feathers MongoDB Service', () => {
 
       await peopleService.remove(person._id);
     });
+    
+    it('should return a record with string id', async () => {
+      const person = await peopleService.create({ _id: 'StringID1234', name: 'StringID' });
+      const result = await peopleService.get(person._id.toString());
+
+      expect(result.name).to.equal('StringID');
+
+      await peopleService.remove(person._id);
+    });
 
     it('sorts with default behavior without collation param', async () => {
       const results = await peopleService.find({ query: { $sort: { name: -1 } } });


### PR DESCRIPTION
ObjectID.isValid is a horribly unreliable way to determine if we should employ it. for instance, it returns true on 'lessonKTDA03', but returns false on 'lessonKA07'.

A timely version update would be appreciated :)

Relevant discussions:
https://github.com/feathersjs/docs/issues/1258#issuecomment-522804046
https://feathersjs.slack.com/archives/C0HJE6A65/p1566254632037400


### Summary
- [x] Tell us about the problem your pull request is solving.
- [x] Are there any open issues that are related to this?
- [x] Is this PR dependent on PRs in other repos?
