### PR TITLE
allow _setID override for string ID only mode

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -98,7 +98,7 @@ class Service extends AdapterService {
     }
     // If we have a $set, then attach to the data object
     if (Object.keys(set).length > 0) {
-      data['$set'] = set;
+      data.$set = set;
     }
     return data;
   }
@@ -181,21 +181,23 @@ class Service extends AdapterService {
     }).then(select(params, this.id)).catch(errorHandler);
   }
 
-  _create (data, params = {}) {
-    const setId = item => {
+  _setId (ctx) {
+    return (item) => {
       const entry = Object.assign({}, item);
 
       // Generate a MongoId if we use a custom id
-      if (this.id !== '_id' && typeof entry[this.id] === 'undefined') {
-        entry[this.id] = new ObjectID().toHexString();
+      if (ctx.id !== '_id' && typeof entry[ctx.id] === 'undefined') {
+        entry[ctx.id] = new ObjectID().toHexString();
       }
 
       return entry;
     };
+  }
 
+  _create (data, params = {}) {
     const promise = Array.isArray(data)
-      ? this.Model.insertMany(data.map(setId))
-      : this.Model.insertOne(setId(data));
+      ? this.Model.insertMany(data.map(this._setId(this)))
+      : this.Model.insertOne(this._setId(this)(data));
 
     return promise.then(result => result.ops.length > 1 ? result.ops : result.ops[0])
       .then(select(params, this.id))


### PR DESCRIPTION
### Summary
Related to #150 and #151

Allow override of setID. Which would allow creation of custom string ID's for new objects under _id. Overriding is absolutely necessary as stringID's don't work reliably #151 , even if we made an application wide hook, they would still randomly fail when handled by feathers-mongodb