### PR TITLE
Remove automated ObjectID conversion

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,21 +25,13 @@ class Service extends AdapterService {
     this.options.Model = value;
   }
 
-  _objectifyId (id) {
-    if (this.id === '_id' && ObjectID.isValid(id)) {
-      id = new ObjectID(id.toString());
-    }
-
-    return id;
-  }
-
   _multiOptions (id, params = {}) {
     const { query } = this.filterQuery(params);
     const options = Object.assign({ multi: true }, params.mongodb || params.options);
 
     if (id !== null) {
       options.multi = false;
-      query.$and = (query.$and || []).concat({ [this.id]: this._objectifyId(id) });
+      query.$and = (query.$and || []).concat({ [this.id]: id });
     }
 
     return { query, options };
@@ -98,7 +90,7 @@ class Service extends AdapterService {
     }
     // If we have a $set, then attach to the data object
     if (Object.keys(set).length > 0) {
-      data['$set'] = set;
+      data.$set = set;
     }
     return data;
   }
@@ -106,12 +98,6 @@ class Service extends AdapterService {
   _find (params = {}) {
     // Start with finding all, and limit when necessary.
     const { filters, query, paginate } = this.filterQuery(params);
-
-    // Objectify the id field if it's present
-    if (query[this.id]) {
-      query[this.id] = this._objectifyId(query[this.id]);
-    }
-
     const q = this.Model.find(query);
 
     if (filters.$select) {
@@ -170,7 +156,7 @@ class Service extends AdapterService {
   _get (id, params = {}) {
     const { query } = this.filterQuery(params);
 
-    query.$and = (query.$and || []).concat({ [this.id]: this._objectifyId(id) });
+    query.$and = (query.$and || []).concat({ [this.id]: id });
 
     return this.Model.findOne(query).then(data => {
       if (!data) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -126,24 +126,8 @@ describe('Feathers MongoDB Service', () => {
   });
 
   describe('Service utility functions', () => {
-    describe('objectifyId', () => {
-      it('returns an ObjectID instance for a valid ID', () => {
-        let id = new ObjectID();
-        let result = service({ Model: db })._objectifyId(id.toString(), '_id');
-        expect(result).to.be.instanceof(ObjectID);
-        expect(result).to.deep.equal(id);
-      });
-
-      it('does not return an ObjectID instance for an invalid ID', () => {
-        let id = 'non-valid object id';
-        let result = service({ Model: db })._objectifyId(id.toString(), '_id');
-        expect(result).to.not.be.instanceof(ObjectID);
-        expect(result).to.deep.equal(id);
-      });
-    });
-
     describe('multiOptions', () => {
-      let params = {
+      const params = {
         query: {
           age: 21
         },
@@ -153,8 +137,8 @@ describe('Feathers MongoDB Service', () => {
       };
 
       it('returns valid result when passed an ID', () => {
-        let id = new ObjectID();
-        let result = service({ Model: db })._multiOptions(id, params);
+        const id = new ObjectID();
+        const result = service({ Model: db })._multiOptions(id, params);
         expect(result).to.be.an('object');
         expect(result).to.include.all.keys(['query', 'options']);
         expect(result.query).to.deep.equal(Object.assign({}, params.query, { $and: [{ _id: id }] }));
@@ -162,7 +146,7 @@ describe('Feathers MongoDB Service', () => {
       });
 
       it('returns original object', () => {
-        let result = service({ Model: db })._multiOptions(null, params);
+        const result = service({ Model: db })._multiOptions(null, params);
         expect(result).to.be.an('object');
         expect(result).to.include.all.keys(['query', 'options']);
         expect(result.query).to.deep.equal(params.query);
@@ -222,15 +206,27 @@ describe('Feathers MongoDB Service', () => {
       ]).catch(() => {});
     });
 
-    it('should coerce the id field to an objectId in find', async () => {
+    it('queries for ObjectId in find', async () => {
       const person = await peopleService.create({ name: 'Coerce' });
       const results = await peopleService.find({
         query: {
-          _id: person._id.toString()
+          _id: new ObjectID(person._id)
         }
       });
 
       expect(results).to.have.lengthOf(1);
+
+      await peopleService.remove(person._id);
+    });
+
+    it('works with normal string _id', async () => {
+      const person = await peopleService.create({
+        _id: 'lessonKTDA08',
+        name: 'Coerce'
+      });
+      const result = await peopleService.get(person._id);
+
+      expect(result.name).to.equal('Coerce');
 
       await peopleService.remove(person._id);
     });


### PR DESCRIPTION
This pull request removes the implicit conversion of id fields to object ids. It is causing issues (#151) when using other strings as ids and the documentation already states in https://github.com/feathersjs-ecosystem/feathers-mongodb#querying that ObjectIDs should be converted explicitly. All other tests are still passing.

- Closes https://github.com/feathersjs-ecosystem/feathers-mongodb/issues/151
- Closes #152
- Closes https://github.com/feathersjs-ecosystem/feathers-mongodb/pull/150
