### PR TITLE
Add disableObjectify option to use normal strings as id

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ __Options:__
 
 - `Model` (**required**) - The MongoDB collection instance
 - `id` (*optional*, default: `'_id'`) - The name of the id field property. By design, MongoDB will always add an `_id` property.
+- `disableObjectify` (*optional*, default `false`) - This will disable the objectify of the id field if you want to use normal strings
 - `events` (*optional*) - A list of [custom service events](https://docs.feathersjs.com/api/events.html#custom-events) sent by this service
 - `paginate` (*optional*) - A [pagination object](https://docs.feathersjs.com/api/databases/common.html#pagination) containing a `default` and `max` page size
 - `whitelist` (*optional*) - A list of additional query parameters to allow (e..g `[ '$regex', '$geoNear' ]`)
@@ -116,9 +117,9 @@ Run the example with `node app` and go to [localhost:3030/messages](http://local
 
 Additionally to the [common querying mechanism](https://docs.feathersjs.com/api/databases/querying.html) this adapter also supports [MongoDB's query syntax](https://docs.mongodb.com/v3.2/tutorial/query-documents/) and the `update` method also supports MongoDB [update operators](https://docs.mongodb.com/v3.2/reference/operator/update/).
 
-> **Important:** External query values through HTTP URLs may have to be converted to the same type stored in MongoDB in a before [hook](https://docs.feathersjs.com/api/hooks.html) otherwise no matches will be found. This includes querying for `_id` which is a MongoID, e.g. with `$in`. See [feathersjs/feathers/issues/757](https://github.com/feathersjs/feathers/issues/757). Websocket requests will maintain the correct format if it is supported by JSON (ObjectIDs and dates still have to be converted).
+> **Important:** External query values through HTTP URLs may have to be converted to the same type stored in MongoDB in a before [hook](https://docs.feathersjs.com/api/hooks.html) otherwise no matches will be found. Websocket requests will maintain the correct format if it is supported by JSON (ObjectIDs and dates still have to be converted).
 
-For example, a `find` call for `_id` (which is a MongoDB object id) and `age` (which is a number) a hook like this can be used:
+For example, an `age` (which is a number) a hook like this can be used:
 
 ```js
 const ObjectID = require('mongodb').ObjectID;
@@ -127,10 +128,6 @@ app.service('users').hooks({
   before: {
     find(context) {
       const { query = {} } = context.params;
-
-      if(query._id) {
-        query._id  = new ObjectID(query._id);
-      }
 
       if(query.age !== undefined) {
         query.age = parseInt(query.age, 10);

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,13 +25,25 @@ class Service extends AdapterService {
     this.options.Model = value;
   }
 
+  _objectifyId (id) {
+    if (this.options.disableObjectify) {
+      return id;
+    }
+
+    if (this.id === '_id' && ObjectID.isValid(id)) {
+      id = new ObjectID(id.toString());
+    }
+
+    return id;
+  }
+
   _multiOptions (id, params = {}) {
     const { query } = this.filterQuery(params);
     const options = Object.assign({ multi: true }, params.mongodb || params.options);
 
     if (id !== null) {
       options.multi = false;
-      query.$and = (query.$and || []).concat({ [this.id]: id });
+      query.$and = (query.$and || []).concat({ [this.id]: this._objectifyId(id) });
     }
 
     return { query, options };
@@ -98,6 +110,11 @@ class Service extends AdapterService {
   _find (params = {}) {
     // Start with finding all, and limit when necessary.
     const { filters, query, paginate } = this.filterQuery(params);
+
+    if (query[this.id]) {
+      query[this.id] = this._objectifyId(query[this.id]);
+    }
+
     const q = this.Model.find(query);
 
     if (filters.$select) {
@@ -156,7 +173,7 @@ class Service extends AdapterService {
   _get (id, params = {}) {
     const { query } = this.filterQuery(params);
 
-    query.$and = (query.$and || []).concat({ [this.id]: id });
+    query.$and = (query.$and || []).concat({ [this.id]: this._objectifyId(id) });
 
     return this.Model.findOne(query).then(data => {
       if (!data) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -126,6 +126,22 @@ describe('Feathers MongoDB Service', () => {
   });
 
   describe('Service utility functions', () => {
+    describe('objectifyId', () => {
+      it('returns an ObjectID instance for a valid ID', () => {
+        const id = new ObjectID();
+        const result = service({ Model: db })._objectifyId(id.toString(), '_id');
+        expect(result).to.be.instanceof(ObjectID);
+        expect(result).to.deep.equal(id);
+      });
+
+      it('does not return an ObjectID instance for an invalid ID', () => {
+        const id = 'non-valid object id';
+        const result = service({ Model: db })._objectifyId(id.toString(), '_id');
+        expect(result).to.not.be.instanceof(ObjectID);
+        expect(result).to.deep.equal(id);
+      });
+    });
+
     describe('multiOptions', () => {
       const params = {
         query: {
@@ -190,6 +206,7 @@ describe('Feathers MongoDB Service', () => {
     beforeEach(async () => {
       peopleService = app.service('/people');
       peopleService.options.multi = true;
+      peopleService.options.disableObjectify = true;
       people = await Promise.all([
         peopleService.create({ name: 'AAA' }),
         peopleService.create({ name: 'aaa' }),


### PR DESCRIPTION
Hello,

### Summary

This PR is an attempt to resolve https://github.com/feathersjs/feathers/issues/1660.

The problem is that the objectify of _id need to be done in the adapter IMHO because without that it break a lot of things for MongoDB and the third party libs.

This add a disableObjectify option that can be use in the service that will disable the objectify of the `id field`. If user want to use strings which is not the normal MongoDB behavior, you can add this option.

Thanks