### PR TITLE
add methodQuery parameter for patch and update

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -211,6 +211,9 @@ class Service extends AdapterService {
     if (params.collation) {
       query = Object.assign(query, { collation: params.collation });
     }
+    if (params.methodQuery) {
+      query = Object.assign(query, params.methodQuery);
+    }
 
     const findParams = Object.assign({}, params, {
       paginate: false
@@ -230,7 +233,10 @@ class Service extends AdapterService {
       );
     }
 
-    const { query, options } = this._multiOptions(id, params);
+    let { query, options } = this._multiOptions(id, params);
+    if (params.methodQuery) {
+      query = Object.assign(query, params.methodQuery);
+    }
 
     return this.Model.replaceOne(query, this._normalizeId(id, data), options)
       .then(() => this._findOrGet(id, params))

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,4 @@
 const { expect } = require('chai');
-require('chai-as-promised');
 const { MongoClient, ObjectID } = require('mongodb');
 const adapterTests = require('@feathersjs/adapter-tests');
 
@@ -191,10 +190,9 @@ describe('Feathers MongoDB Service', () => {
   });
 
   describe('Special methodQuery param', () => {
-
     it('should not update when non matching query is present in methodQuery', async () => {
       const peopleService = app.service('/people');
-      const peop = await peopleService.create({ name: 'AAA' })
+      const peop = await peopleService.create({ name: 'AAA' });
       const updated = await peopleService.update(peop._id, { ...peop, name: 'BBB' }, { methodQuery: { name: 'CCC' } });
       expect(updated).to.deep.equal(peop);
       await peopleService.remove(peop._id);
@@ -202,7 +200,7 @@ describe('Feathers MongoDB Service', () => {
 
     it('should successfully update when matching query is present in methodQuery', async () => {
       const peopleService = app.service('/people');
-      const peop = await peopleService.create({ name: 'AAA' })
+      const peop = await peopleService.create({ name: 'AAA' });
       const patched = await peopleService.update(peop._id, { ...peop, name: 'BBB' }, { methodQuery: { name: 'AAA' } });
       const patchedExpected = { ...peop, name: 'BBB' };
       expect(patched).to.deep.equal(patchedExpected);
@@ -211,7 +209,7 @@ describe('Feathers MongoDB Service', () => {
 
     it('should not patch when non matching query is present in methodQuery', async () => {
       const peopleService = app.service('/people');
-      const peop = await peopleService.create({ name: 'AAA' })
+      const peop = await peopleService.create({ name: 'AAA' });
       const patched = await peopleService.patch(peop._id, { name: 'BBB' }, { methodQuery: { name: 'CCC' } });
       expect(patched).to.deep.equal(peop);
       await peopleService.remove(peop._id);
@@ -219,13 +217,12 @@ describe('Feathers MongoDB Service', () => {
 
     it('should successfully patch when matching query is present in methodQuery', async () => {
       const peopleService = app.service('/people');
-      const peop = await peopleService.create({ name: 'AAA' })
+      const peop = await peopleService.create({ name: 'AAA' });
       const patched = await peopleService.patch(peop._id, { name: 'BBB' }, { methodQuery: { name: 'AAA' } });
       const patchedExpected = { ...peop, name: 'BBB' };
       expect(patched).to.deep.equal(patchedExpected);
       await peopleService.remove(peop._id);
     });
-
   });
 
   describe('Special collation param', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,5 @@
 const { expect } = require('chai');
+require('chai-as-promised');
 const { MongoClient, ObjectID } = require('mongodb');
 const adapterTests = require('@feathersjs/adapter-tests');
 
@@ -79,7 +80,8 @@ describe('Feathers MongoDB Service', () => {
 
   before(() =>
     MongoClient.connect('mongodb://localhost:27017/feathers-test', {
-      useNewUrlParser: true
+      useNewUrlParser: true,
+      useUnifiedTopology: true
     }).then(function (client) {
       mongoClient = client;
       db = client.db('feathers-test');
@@ -186,6 +188,44 @@ describe('Feathers MongoDB Service', () => {
         expect(result).to.deep.equal(projectFields);
       });
     });
+  });
+
+  describe('Special methodQuery param', () => {
+
+    it('should not update when non matching query is present in methodQuery', async () => {
+      const peopleService = app.service('/people');
+      const peop = await peopleService.create({ name: 'AAA' })
+      const updated = await peopleService.update(peop._id, { ...peop, name: 'BBB' }, { methodQuery: { name: 'CCC' } });
+      expect(updated).to.deep.equal(peop);
+      await peopleService.remove(peop._id);
+    });
+
+    it('should successfully update when matching query is present in methodQuery', async () => {
+      const peopleService = app.service('/people');
+      const peop = await peopleService.create({ name: 'AAA' })
+      const patched = await peopleService.update(peop._id, { ...peop, name: 'BBB' }, { methodQuery: { name: 'AAA' } });
+      const patchedExpected = { ...peop, name: 'BBB' };
+      expect(patched).to.deep.equal(patchedExpected);
+      await peopleService.remove(peop._id);
+    });
+
+    it('should not patch when non matching query is present in methodQuery', async () => {
+      const peopleService = app.service('/people');
+      const peop = await peopleService.create({ name: 'AAA' })
+      const patched = await peopleService.patch(peop._id, { name: 'BBB' }, { methodQuery: { name: 'CCC' } });
+      expect(patched).to.deep.equal(peop);
+      await peopleService.remove(peop._id);
+    });
+
+    it('should successfully patch when matching query is present in methodQuery', async () => {
+      const peopleService = app.service('/people');
+      const peop = await peopleService.create({ name: 'AAA' })
+      const patched = await peopleService.patch(peop._id, { name: 'BBB' }, { methodQuery: { name: 'AAA' } });
+      const patchedExpected = { ...peop, name: 'BBB' };
+      expect(patched).to.deep.equal(patchedExpected);
+      await peopleService.remove(peop._id);
+    });
+
   });
 
   describe('Special collation param', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -201,9 +201,9 @@ describe('Feathers MongoDB Service', () => {
     it('should successfully update when matching query is present in methodQuery', async () => {
       const peopleService = app.service('/people');
       const peop = await peopleService.create({ name: 'AAA' });
-      const patched = await peopleService.update(peop._id, { ...peop, name: 'BBB' }, { methodQuery: { name: 'AAA' } });
-      const patchedExpected = { ...peop, name: 'BBB' };
-      expect(patched).to.deep.equal(patchedExpected);
+      const updated = await peopleService.update(peop._id, { ...peop, name: 'BBB' }, { methodQuery: { name: 'AAA' } });
+      const updatedExpected = { ...peop, name: 'BBB' };
+      expect(updated).to.deep.equal(updatedExpected);
       await peopleService.remove(peop._id);
     });
 


### PR DESCRIPTION
I have come across this twice in the last two weeks and decided to draft a solution. When I update a field that is included in the query of an `update` or `patch` call, then the subsequent `get` will yield a `not found` error. This is due to the fact that the query is included in both the `update`/`patch` call and the subsequent `get`.

In this PR i propose to add a separate parameter field `methodQuery` that is only used in the primary call to `updateMany` or `replaceOne` and not used in the subsequent `get` call.

See also
https://github.com/feathersjs-ecosystem/feathers-hooks-common/issues/584
