### PR TITLE
feat: Added useEstimatedDocumentCount option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ __Options:__
 - `paginate` (*optional*) - A [pagination object](https://docs.feathersjs.com/api/databases/common.html#pagination) containing a `default` and `max` page size
 - `whitelist` (*optional*) - A list of additional query parameters to allow (e..g `[ '$regex', '$geoNear' ]`)
 - `multi` (*optional*) - Allow `create` with arrays and `update` and `remove` with `id` `null` to change multiple items. Can be `true` for all methods or an array of allowed methods (e.g. `[ 'remove', 'create' ]`)
+- `useEstimatedDocumentCount` (*optional*, default `false`) - If `true` document counting will rely on `estimatedDocumentCount` instead of `countDocuments`
 
 ### params.mongodb
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -164,7 +164,11 @@ class Service extends AdapterService {
     }
 
     if (paginate && paginate.default) {
-      return this.Model.countDocuments(query).then(runQuery);
+      if (this.options.useEstimatedDocumentCount && (typeof this.Model.estimatedDocumentCount === 'function')) {
+        return this.Model.estimatedDocumentCount(query).then(runQuery);
+      } else {
+        return this.Model.countDocuments(query).then(runQuery);
+      }
     }
 
     return runQuery().then(page => page.data);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -90,6 +90,10 @@ describe('Feathers MongoDB Service', () => {
         Model: db.collection('people-customid'),
         id: 'customid',
         events: ['testing']
+      })).use('/people-estimated-count', service({
+        Model: db.collection('people-estimated-count'),
+        events: ['testing'],
+        useEstimatedDocumentCount: true
       }));
 
       app.service('people').Model = db.collection('people');
@@ -331,4 +335,5 @@ describe('Feathers MongoDB Service', () => {
 
   testSuite(app, errors, 'people', '_id');
   testSuite(app, errors, 'people-customid', 'customid');
+  testSuite(app, errors, 'people-estimated-count', '_id');
 });


### PR DESCRIPTION
Added a new `useEstimatedDocumentCount` option  (default `false`) - If `true` document counting will rely on `estimatedDocumentCount()` instead of `countDocuments()`.

Closes https://github.com/feathersjs-ecosystem/feathers-mongodb/issues/185

