### PR TITLE
Add support for passing `options` (or `mongodb`) to all methods.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,6 +49,12 @@ class Service extends AdapterService {
     return { query, options };
   }
 
+  _options (params = {}) {
+    const { filters, query, paginate } = this.filterQuery(params);
+    const options = Object.assign({}, params.mongodb || params.options);
+    return { filters, query, paginate, options };
+  }
+
   _getSelect (select) {
     if (Array.isArray(select)) {
       var result = {};
@@ -109,13 +115,13 @@ class Service extends AdapterService {
 
   _find (params = {}) {
     // Start with finding all, and limit when necessary.
-    const { filters, query, paginate } = this.filterQuery(params);
+    const { filters, query, paginate, options } = this._options(params);
 
     if (query[this.id]) {
       query[this.id] = this._objectifyId(query[this.id]);
     }
 
-    const q = this.Model.find(query);
+    const q = this.Model.find(query, options);
 
     if (filters.$select) {
       q.project(this._getSelect(filters.$select));
@@ -165,9 +171,9 @@ class Service extends AdapterService {
 
     if (paginate && paginate.default) {
       if (this.options.useEstimatedDocumentCount && (typeof this.Model.estimatedDocumentCount === 'function')) {
-        return this.Model.estimatedDocumentCount(query).then(runQuery);
+        return this.Model.estimatedDocumentCount(query, options).then(runQuery);
       } else {
-        return this.Model.countDocuments(query).then(runQuery);
+        return this.Model.countDocuments(query, options).then(runQuery);
       }
     }
 
@@ -175,11 +181,11 @@ class Service extends AdapterService {
   }
 
   _get (id, params = {}) {
-    const { query } = this.filterQuery(params);
+    const { query, options } = this._options(params);
 
     query.$and = (query.$and || []).concat({ [this.id]: this._objectifyId(id) });
 
-    return this.Model.findOne(query).then(data => {
+    return this.Model.findOne(query, options).then(data => {
       if (!data) {
         throw new errors.NotFound(`No record found for id '${id}'`);
       }
@@ -189,6 +195,7 @@ class Service extends AdapterService {
   }
 
   _create (data, params = {}) {
+    const { options } = this._options(params);
     const setId = item => {
       const entry = Object.assign({}, item);
 
@@ -201,8 +208,8 @@ class Service extends AdapterService {
     };
 
     const promise = Array.isArray(data)
-      ? this.Model.insertMany(data.map(setId))
-      : this.Model.insertOne(setId(data));
+      ? this.Model.insertMany(data.map(setId), options)
+      : this.Model.insertOne(setId(data), options);
 
     return promise.then(result => result.ops.length > 1 ? result.ops : result.ops[0])
       .then(select(params, this.id))
@@ -257,7 +264,7 @@ class Service extends AdapterService {
   }
 
   _remove (id, params = {}) {
-    let { query } = this._multiOptions(id, params);
+    let { query, options } = this._multiOptions(id, params);
 
     if (params.collation) {
       query = Object.assign(query, { collation: params.collation });
@@ -270,7 +277,7 @@ class Service extends AdapterService {
 
     return this._findOrGet(id, findParams)
       .then(items => {
-        return this.Model.deleteMany(query)
+        return this.Model.deleteMany(query, options)
           .then(() => items)
           .then(select(params, this.id));
       }).catch(errorHandler);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -147,7 +147,7 @@ describe('Feathers MongoDB Service', () => {
       });
     });
 
-    describe('multiOptions', () => {
+    describe('_multiOptions', () => {
       const params = {
         query: {
           age: 21
@@ -172,6 +172,25 @@ describe('Feathers MongoDB Service', () => {
         expect(result).to.include.all.keys(['query', 'options']);
         expect(result.query).to.deep.equal(params.query);
         expect(result.options).to.deep.equal(Object.assign({}, params.options, { multi: true }));
+      });
+    });
+
+    describe('_options', () => {
+      const params = {
+        query: {
+          age: 21
+        },
+        options: {
+          limit: 5
+        }
+      };
+
+      it('returns original object', () => {
+        const result = service({ Model: db })._options(params);
+        expect(result).to.be.an('object');
+        expect(result).to.include.all.keys(['options', 'filters', 'query', 'paginate']);
+        expect(result.query).to.deep.equal(params.query);
+        expect(result.options).to.deep.equal(Object.assign({}, params.options));
       });
     });
 


### PR DESCRIPTION
Previously only methods that allowed the `multi` option supported
additional passed option. That change adds support for all other
methods, ultimately calling e.g. `find`, `findAndModify`

This indirectly address #127 as a MongoDB `session` can be via `options` (or `mongodb`). Allowing the user to do something like the following:

```
import { ObjectID } from 'mongodb'

export default async app => {
  app.use('/fooBarService', {
    async create(data) {
      // assumes you have access to the mongoClient via your app state
      let session = app.mongoClient.startSession()
      try {
        await session.withTransaction(async () => {
            let fooID = new ObjectID()
            let barID = new ObjectID()
            app.service('fooService').create(
              { 
                ...data,
                _id: fooID,
                bar: barID,
              },
              { mongodb: { session } },
            )
            app.service('barService').create(
              {
                ...data,
                _id: barID
                foo: fooID
              },
              { mongodb: { session } },
            )
        })
      } finally {
        await session.endSession()
      }
    }
  })
}
```
