### PR TITLE
fix: add missing options on findOne in _create

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -212,11 +212,11 @@ class Service extends AdapterService {
 
     return promise.then(result => {
       if (result.insertedId) {
-        return this.Model.findOne({ _id: result.insertedId });
+        return this.Model.findOne({ _id: result.insertedId }, options);
       }
 
       if (result.insertedIds) {
-        return Promise.all(Object.values(result.insertedIds).map(_id => this.Model.findOne({ _id })));
+        return Promise.all(Object.values(result.insertedIds).map(_id => this.Model.findOne({ _id }, options)));
       }
 
       return result.ops.length > 1 ? result.ops : result.ops[0];


### PR DESCRIPTION
### Summary

options are needed to get the transactions/sessions to work. Otherwise the create are done on one session and the find is done on another.
